### PR TITLE
Bug fixed in spase2jpcoar2_0.xsl

### DIFF
--- a/spase2jpcoar2_0.xsl
+++ b/spase2jpcoar2_0.xsl
@@ -294,9 +294,9 @@
             <xsl:value-of select="spase:Project"/>
         </jpcoar:awardTitle>
         <xsl:if test="spase:AwardNumber">
-            <datacite:awardNumber>
+            <jpcoar:awardNumber>
                 <xsl:value-of select="spase:AwardNumber"/>
-            </datacite:awardNumber>
+            </jpcoar:awardNumber>
         </xsl:if>
     </jpcoar:fundingReference>
 </xsl:template>


### PR DESCRIPTION
Fixed a bug.
In the file spase2jpcoar2_0.xsl, the element name should be 'jpcoar:awardNumber', but it was 'datacite:awardNumber'.